### PR TITLE
Remove JSON parsing which is prone to errors

### DIFF
--- a/lib/mongoose-fs.js
+++ b/lib/mongoose-fs.js
@@ -39,7 +39,7 @@ var mongooseFSPlugin = function (schema, options) {
         if(err) {
           return cb(err);
         }
-        this[key] = data.toString();
+        this[key] = data;
         cnt ++;
         if(cnt === options.keys.length) {
           cb(null, this);


### PR DESCRIPTION
JSON parsing is not reliable when using binary data and can cause crashes when retrieving blobs. Because data is already inserted into GridFS as a buffer, the layer where the buffer is parsed into JSON has been completely removed. Also, the content type has been changed to 'application/octet-stream', which represents arbitrary binary data.
